### PR TITLE
Improve prebuild

### DIFF
--- a/pre-build.js
+++ b/pre-build.js
@@ -30,7 +30,9 @@ const dependencies = topLevelDirectories.map(collectDependencies)
     .reduce((accumulator, current) => {
         const cached = accumulator[current.name]
         if (cached && cached !== current.version) {
-            console.log('conflict', cached, 'using:', current.name, current.version)
+            console.log('conflict with', current.name, 'using:', cached, 'instead of', current.version)
+            console.log('\n')
+            return accumulator
         }
         return accumulator[current.name] = current.version, accumulator
     }, {})

--- a/pre-build.js
+++ b/pre-build.js
@@ -29,7 +29,7 @@ const dependencies = topLevelDirectories.map(collectDependencies)
     }, [])
     .reduce((accumulator, current) => {
         const cached = accumulator[current.name]
-        if (cached) {
+        if (cached && cached !== current.version) {
             console.log('conflict', cached, 'using:', current.name, current.version)
         }
         return accumulator[current.name] = current.version, accumulator

--- a/pre-build.js
+++ b/pre-build.js
@@ -12,16 +12,22 @@ const topLevelDirectories = fs.readdirSync('./')
 
 const collectDependencies = (file) => {
     const packageFile = fs.readFileSync(path.join(file, 'package.json'))
-    return JSON.parse(packageFile).dependencies
+    return { 
+        location: file,
+        dependencies: JSON.parse(packageFile).dependencies
+     }
 }
 
 const dependencies = topLevelDirectories.map(collectDependencies)
-    .map(dependenciesBlock => {
+    .map(each => {
+        const dependenciesBlock  = each.dependencies
+        const location = each.location
         return Object.keys(dependenciesBlock).map(key => {
             const version = dependenciesBlock[key]
             return {
                 name: key,
                 version: version,
+                location
             }
         })
     }).reduce((accumulator, current) => {
@@ -30,7 +36,7 @@ const dependencies = topLevelDirectories.map(collectDependencies)
     .reduce((accumulator, current) => {
         const cached = accumulator[current.name]
         if (cached && cached !== current.version) {
-            console.log('conflict with', current.name, 'using:', cached, 'instead of', current.version)
+            console.log('conflict in', current.location, 'with', current.name, 'using:', cached, 'instead of', current.version)
             console.log('\n')
             return accumulator
         }


### PR DESCRIPTION
- Only print warnings for version conflicts, rather than all duplicated dependencies
- Conflicting dependencies are first come first serve, meaning we should avoid ALL conflicts to ensure the dependency behaviour is expected.
- Improves the conflict message 


```
conflict in repo-issues with moment using: ^2.20.1 instead of ^2.21.0
conflict in tfl-status with dashboard-plugin using: https://github.com/novoda/dashboards/blob/master/plugin/dashboard-plugin-1.0.4.tgz?raw=true 
instead of https://github.com/novoda/dashboards/blob/master/plugin/dashboard-plugin-1.0.3.tgz?raw=true
```