### PR TITLE
Access config correctly by reading its value

### DIFF
--- a/repo-issues/lib/data-source.js
+++ b/repo-issues/lib/data-source.js
@@ -15,11 +15,11 @@ let showPRs
 let show_details_threshold
 
 const generateViewState = (configuration) => {
-    showIssues = configuration.showIssues === 'true'
-    showPRs = configuration.showPRs === 'true'
-    show_details_threshold = parseInt(configuration.showDetailsThreshold, 10)
+    showIssues = configuration.showIssues.value === 'true'
+    showPRs = configuration.showPRs.value === 'true'
+    show_details_threshold = parseInt(configuration.showDetailsThreshold.value, 10)
 
-    octokit.authenticate({type: 'oauth', token: `${configuration.token}`})
+    octokit.authenticate({type: 'oauth', token: configuration.token.value})
 
     return paginate(octokit.repos.getForOrg)
         .then(data => Promise.all(data.map(queryRepoIssues)))


### PR DESCRIPTION
This fixes a production error reading configuration
To reproduce it locally it's necessary to pass configuration using a `config.json` (instead of hardcoding it)
