### PR TITLE
Add football plugin

### DIFF
--- a/football/config.json
+++ b/football/config.json
@@ -1,0 +1,5 @@
+{
+    "competitionId": {
+        "value": 456
+    }
+}

--- a/football/config.json
+++ b/football/config.json
@@ -1,5 +1,0 @@
-{
-    "competitionId": {
-        "value": 456
-    }
-}

--- a/football/lib/data-source.js
+++ b/football/lib/data-source.js
@@ -1,10 +1,10 @@
 const http = require('request-promise-native')
 
-const fetchCompetition = (competitionId) => {
+const fetchCompetition = (competitionId, authToken) => {
     const request = {
         url: `http://api.football-data.org/v1/competitions/${competitionId}`,
         headers: {
-            'X-Auth-Token': 'f7ed7ab3066343fd897113e9d281e1f2', 'X-Response-Control': 'minified'
+            'X-Auth-Token': authToken, 'X-Response-Control': 'minified'
         }
     }
     return http.get(request)
@@ -12,15 +12,17 @@ const fetchCompetition = (competitionId) => {
 
 const generateViewState = (configuration) => {
     const competitionIdValue = configuration.competitionId.value
-    return Promise.all([fetchCompetition(competitionIdValue)])
-        .then(results => toViewState(results)(competitionIdValue))
+    const authTokenValue = configuration.authToken.value
+    return Promise.all([fetchCompetition(competitionIdValue, authTokenValue)])
+        .then(results => toViewState(results)(competitionIdValue, authTokenValue))
 }
 
-const toViewState = (rawResponses) => (competitionId) => {
+const toViewState = (rawResponses) => (competitionId, authToken) => {
     const competitionResponse = JSON.parse(rawResponses[0])
 
     return {
         competitionId: competitionId,
+        authToken: authToken,
         competition: competitionResponse[`caption`],
         matchDay: competitionResponse[`currentMatchday`],
         totalMatchDays: competitionResponse[`numberOfMatchdays`]

--- a/football/lib/data-source.js
+++ b/football/lib/data-source.js
@@ -1,0 +1,31 @@
+const http = require('request-promise-native')
+
+const fetchCompetition = (competitionId) => {
+    const request = {
+        url: `http://api.football-data.org/v1/competitions/${competitionId}`,
+        headers: {
+            'X-Auth-Token': 'f7ed7ab3066343fd897113e9d281e1f2', 'X-Response-Control': 'minified'
+        }
+    }
+    return http.get(request)
+}
+
+const generateViewState = (configuration) => {
+    const competitionIdValue = configuration.competitionId.value
+    return Promise.all([fetchCompetition(competitionIdValue)])
+        .then(results => toViewState(results)(competitionIdValue))
+}
+
+const toViewState = (rawResponses) => (competitionId) => {
+    const competitionResponse = JSON.parse(rawResponses[0])
+
+    return {
+        competitionId: competitionId,
+        competition: competitionResponse[`caption`],
+        matchDay: competitionResponse[`currentMatchday`],
+        totalMatchDays: competitionResponse[`numberOfMatchdays`]
+    }
+}
+
+
+module.exports = generateViewState

--- a/football/lib/flagMapper.js
+++ b/football/lib/flagMapper.js
@@ -1,0 +1,72 @@
+const flagForTeam = (teamName) => {
+    switch (teamName) {
+        case `Russia`:
+            return `🇷🇺`
+        case `Saudi Arabia`:
+            return `🇸🇦`
+        case `Egypt`:
+            return `🇪🇬`
+        case `Uruguay`:
+            return `🇺🇾`
+        case `Morocco`:
+            return `🇲🇦`
+        case `Iran`:
+            return `🇮🇷`
+        case `Portugal`:
+            return `🇵🇹`
+        case `Spain`:
+            return `🇪🇸`
+        case `France`:
+            return `🇫🇷`
+        case `Australia`:
+            return `🇦🇺`
+        case `Argentina`:
+            return `🇦🇷`
+        case `Iceland`:
+            return `🇮🇸`
+        case `Peru`:
+            return `🇵🇪`
+        case `Denmark`:
+            return `🇩🇰`
+        case `Croatia`:
+            return `🇭🇷`
+        case `Nigeria`:
+            return `🇳🇬`
+        case `Costa Rica`:
+            return `🇨🇷`
+        case `Serbia`:
+            return `🇷🇸`
+        case `Germany`:
+            return `🇩🇪`
+        case `Mexico`:
+            return `🇲🇽`
+        case `Brazil`:
+            return `🇧🇷`
+        case `Switzerland`:
+            return `🇨🇭`
+        case `Korea Republic`:
+            return `🇰🇷`
+        case `Belgium`:
+            return `🇧🇪`
+        case `Panama`:
+            return `🇵🇦`
+        case `Tunisia`:
+            return `🇹🇳`
+        case `Sweden`:
+            return `🇸🇪`
+        case `Poland`:
+            return `🇵🇱`
+        case `England`:
+            return `🇬🇧`
+        case `Senegal`:
+            return `🇸🇳`
+        case `Colombia`:
+            return `🇨🇴`
+        case `Japan`:
+            return `🇯🇵`
+        default:
+            break
+    }
+}
+
+module.exports = flagForTeam

--- a/football/lib/index.js
+++ b/football/lib/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    plugin: () => require('./plugin')
+}

--- a/football/lib/plugin.js
+++ b/football/lib/plugin.js
@@ -1,0 +1,26 @@
+const plugin = require('dashboard-plugin')
+const generateViewState = require('./data-source')
+
+const component = {
+    template: 'template.html',
+    __dirname
+}
+
+const configuration = () => {
+    return {
+        "football-plugin": {
+            name: 'football-plugin',
+            template: {
+                awayTeamName: plugin.createStringField('awayTeamName'),
+                homeTeamName: plugin.createStringField('homeTeamName'),
+                homeTeamFlag: plugin.createStringField('homeTeamFlag'),
+                awayTeamFlag: plugin.createStringField('awayTeamFlag'),
+                goalsHomeTeam: plugin.createStringField('goalsHomeTeam'),
+                goalsAwayTeam: plugin.createStringField('goalsAwayTeam'),
+                competition: plugin.createStringField('competition'),
+            }
+        }
+    }
+}
+
+module.exports = plugin.templated(configuration, component, generateViewState)

--- a/football/lib/plugin.js
+++ b/football/lib/plugin.js
@@ -10,15 +10,7 @@ const configuration = () => {
     return {
         "football-plugin": {
             name: 'football-plugin',
-            template: {
-                awayTeamName: plugin.createStringField('awayTeamName'),
-                homeTeamName: plugin.createStringField('homeTeamName'),
-                homeTeamFlag: plugin.createStringField('homeTeamFlag'),
-                awayTeamFlag: plugin.createStringField('awayTeamFlag'),
-                goalsHomeTeam: plugin.createStringField('goalsHomeTeam'),
-                goalsAwayTeam: plugin.createStringField('goalsAwayTeam'),
-                competition: plugin.createStringField('competition'),
-            }
+            template: { }
         }
     }
 }

--- a/football/lib/runtime.js
+++ b/football/lib/runtime.js
@@ -4,12 +4,13 @@
     const array = Array.from(metaTags)
     const competitionId = array.filter(tag => { return tag.getAttribute("name") === "competitionId" }).map(element => element.getAttribute("content"))[0]
     const matchDay = array.filter(tag => { return tag.getAttribute("name") === "matchDay" }).map(element => element.getAttribute("content"))[0]
+    const authToken = array.filter(tag => { return tag.getAttribute("name") === "authToken" }).map(element => element.getAttribute("content"))[0]
 
     const fetchFixtures = (competitionId) => {
         const request = {
             mode:'cors',
             headers: {
-                'X-Auth-Token': 'f7ed7ab3066343fd897113e9d281e1f2', 'X-Response-Control': 'minified'
+                'X-Auth-Token': authToken, 'X-Response-Control': 'minified'
             }
         }
         return fetch(`http://api.football-data.org/v1/competitions/${competitionId}/fixtures`, request).then(response => response.json())

--- a/football/lib/runtime.js
+++ b/football/lib/runtime.js
@@ -1,0 +1,284 @@
+(function () {
+    const metaTags = document.getElementsByTagName("meta")
+    const matchList = document.getElementById("matchList")
+    const array = Array.from(metaTags)
+    const competitionId = array.filter(tag => { return tag.getAttribute("name") === "competitionId" }).map(element => element.getAttribute("content"))[0]
+    const matchDay = array.filter(tag => { return tag.getAttribute("name") === "matchDay" }).map(element => element.getAttribute("content"))[0]
+
+    const fetchFixtures = (competitionId) => {
+        const request = {
+            mode:'cors',
+            headers: {
+                'X-Auth-Token': 'f7ed7ab3066343fd897113e9d281e1f2', 'X-Response-Control': 'minified'
+            }
+        }
+        return fetch(`http://api.football-data.org/v1/competitions/${competitionId}/fixtures`, request).then(response => response.json())
+    }
+
+    const generateViewState = (competitionId) => {
+        return Promise.all([fetchFixtures(competitionId)])
+            .then(results => toViewState(results)(competitionId))
+    }
+
+    const flagForTeam = (teamName) => {
+        switch (teamName) {
+            default:
+                break
+        }
+    }
+
+    const toViewState = (rawResponses) => () => {
+        const fixturesResponse = rawResponses[0]
+        const matches = fixturesResponse[`fixtures`].filter(value => {
+            return value[`matchday`] == matchDay
+        })
+
+        return {
+            matches: matches.map(match => {
+
+                const result = toResult(match[`result`])
+                const status = toColoredStatus(match[`status`])
+                console.log(match[`status`])
+                const homeTeamName = match[`homeTeamName`]
+                const awayTeamName = match[`awayTeamName`]
+
+                return {
+                    date: new Date(match[`date`]).toLocaleString().replace(/:\d{2}\s/,' '),
+                    status: status,
+                    homeTeamName: homeTeamName,
+                    homeTeamFlag: flagForTeam(homeTeamName),
+                    awayTeamName: awayTeamName,
+                    awayTeamFlag: flagForTeam(awayTeamName),
+                    goalsHomeTeam: result.goalsHomeTeam,
+                    goalsAwayTeam: result.goalsAwayTeam,
+                    extraTimeGoalsHome: result.extraTimeGoalsHome,
+                    extraTimeGoalsAway: result.extraTimeGoalsAway,
+                    penaltiesHome: result.penaltiesHome,
+                    penaltiesAway: result.penaltiesAway,
+                }
+            })
+        }
+    }
+
+    const toResult = (resultJSON) => {
+
+        const goalsHome = resultJSON[`goalsHomeTeam`]
+        const goalsAway = resultJSON[`goalsAwayTeam`]
+        const extraTime = resultJSON[`extraTime`]
+        const penaltyShootout = resultJSON[`penaltyShootout`]
+
+        if(goalsHome && goalsAway) {
+            return {
+                goalsHomeTeam: String(goalsHome),
+                goalsAwayTeam: String(goalsAway),
+                extraTimeGoalsHome: toScore(extraTime).goalsHomeTeam,
+                extraTimeGoalsAway: toScore(extraTime).goalsAwayTeam,
+                penaltiesHome: toScore(penaltyShootout).goalsHomeTeam,
+                penaltiesAway: toScore(penaltyShootout).goalsAwayTeam,
+            }
+        }
+
+        return {
+            goalsHomeTeam: String(`-`),
+            goalsAwayTeam: String(`-`),
+        }
+    }
+
+    const toScore = (resultJSON) => {
+        if (resultJSON) {
+            const goalsHome = resultJSON[`goalsHomeTeam`]
+            const goalsAway = resultJSON[`goalsAwayTeam`]
+
+            if (goalsHome && goalsAway) {
+                return {
+                    goalsHomeTeam: String(goalsHome),
+                    goalsAwayTeam: String(goalsAway),
+                }
+            }
+        }
+
+        return {
+            goalsHomeTeam: null,
+            goalsAwayTeam: null,
+        }
+    }
+
+    const toColoredStatus = (status) => {
+        switch (status) {
+            case `FINISHED`:
+                return {
+                    text:`FINISHED`,
+                    color: `coral`
+                }
+            case `IN_PLAY`:
+                return {
+                    text:`LIVE`,
+                    color: `chartreuse`
+                }
+            case `TIMED`:
+                return {
+                    text:`TIMED`,
+                    color: `yellow`
+                }
+            case `SCHEDULED`:
+                return {
+                    text:`SCHEDULED`,
+                    color: `white`
+                }
+            case `POSTPONED`:
+                return {
+                    text:`POSTPONED`,
+                    color: `white`
+                }
+            case `CANCELED`:
+                return {
+                    text:`CANCELED`,
+                    color: `red`
+                }
+            default:
+                return null
+        }
+    }
+
+    const createHTMLForViewState = (viewState) => {
+        matchList.querySelectorAll('li').forEach(element => {
+            matchList.removeChild(element)
+        })
+
+        viewState.matches.forEach(match => {
+
+            var new_row = document.createElement('li');
+            new_row.className = 'matchList'
+
+            var itemDiv = createDiv('item')
+            var matchDiv = createDiv('matchContainer')
+            var teamsContainerDiv = createDiv('teamsContainer')
+            var extraTimeScoreContainerDiv = createDiv('extraTimeScoreContainer')
+
+            var homeTeamSpan = createSpan('homeTeam')(match.homeTeamName)
+            var awayTeamSpan = createSpan('awayTeam')(match.awayTeamName)
+            var homeTeamScore = createSpan('score')(match.goalsHomeTeam)
+            var scoreDash = createSpan('score scoreDivisor')(':')
+            var awayTeamScore = createSpan('score')(match.goalsAwayTeam)
+            var homeExtraTimeScore = createSpan('extraTimeScore')(match.extraTimeGoalsHome)
+            var extraTimeScoreDash = createSpan('extraTimeScore scoreDivisor')(':')
+            var awayExtraTimeScore = createSpan('extraTimeScore')(match.extraTimeGoalsAway)
+
+            /*
+
+            This should be addressed once we find a solution for supporting emojis
+
+            var homeFlagDiv = document.createElement('span')
+            homeFlagDiv.className = 'teamFlag'
+            homeFlagDiv.textContent = match.homeTeamFlag
+
+            var awayFlagDiv = document.createElement('span')
+            awayFlagDiv.className = 'teamFlag'
+            awayFlagDiv.textContent = match.awayTeamFlag
+
+            */
+
+            var statusDiv = document.createElement('div')
+
+            var statusSpan = createSpan('matchStatus')(match.status.text)
+            statusSpan.style.color = match.status.color
+
+            var dateDiv = document.createElement('div')
+
+            var dateSpan = createSpan('date')(match.date)
+
+            new_row.appendChild(itemDiv)
+            itemDiv.appendChild(matchDiv)
+            matchDiv.appendChild(teamsContainerDiv)
+
+            teamsContainerDiv.appendChild(homeTeamSpan)
+            teamsContainerDiv.appendChild(homeTeamScore)
+            teamsContainerDiv.appendChild(scoreDash)
+            teamsContainerDiv.appendChild(awayTeamScore)
+            teamsContainerDiv.appendChild(awayTeamSpan)
+
+            if (match.extraTimeGoalsHome && match.extraTimeGoalsAway) {
+                matchDiv.appendChild(extraTimeScoreContainerDiv)
+                extraTimeScoreContainerDiv.appendChild(homeExtraTimeScore)
+                extraTimeScoreContainerDiv.appendChild(extraTimeScoreDash)
+                extraTimeScoreContainerDiv.appendChild(awayExtraTimeScore)
+            }
+
+            if (match.penaltiesHome && match.penaltiesAway) {
+                var penalties = createPenaltiesDiv(match)
+                matchDiv.appendChild(penalties)
+            }
+
+            matchDiv.appendChild(statusDiv)
+            statusDiv.appendChild(statusSpan)
+            matchDiv.appendChild(dateDiv)
+            dateDiv.appendChild(dateSpan)
+            matchList.appendChild(new_row)
+        })
+    }
+
+    const createDiv = (className) => {
+        var div = document.createElement('div')
+        div.className = className
+        return div
+    }
+
+    const createSpan = (className) => (textContent) => {
+        var span = document.createElement('span')
+        span.className = className
+        span.textContent = textContent
+        return span
+    }
+
+    const createPenaltiesDiv = (match) => {
+        var penalties = createDiv('penalties')
+
+        var penaltiesDiv = createDiv('penaltiesDiv')
+        penalties.appendChild(penaltiesDiv)
+        
+        var penaltiesDivAway = createDiv('penaltiesDiv')
+        penalties.appendChild(penaltiesDivAway)
+        
+        for (i = 0; i < match.penaltiesHome; i++) {
+            var dotContainer = createDotContainer('circleBase')
+            penaltiesDiv.appendChild(dotContainer)
+        }
+        
+        for (i = 0; i < match.penaltiesAway; i++) {
+            var dotContainer = createDotContainer('circleBase')
+            penaltiesDivAway.appendChild(dotContainer)
+        }
+
+        for (i = 0; i < match.penaltiesHome - match.penaltiesAway; i++) {
+            var dotContainer = createDotContainer('circleBaseRed')
+            penaltiesDivAway.appendChild(dotContainer)
+        }
+        
+        for (i = 0; i < match.penaltiesAway - match.penaltiesHome; i++) {
+            var dotContainer = createDotContainer('circleBaseRed')
+            penaltiesDiv.appendChild(dotContainer)
+        }
+
+        return penalties
+    }
+
+    const createDotContainer = (className) => {
+        var dotContainer = document.createElement('div')
+        dotContainer.className = 'dotContainer'
+        var dot = document.createElement('div')
+        dot.className = className
+        dotContainer.appendChild(dot)
+        return dotContainer
+    }
+
+    generateViewState(competitionId).then(viewState => {
+        createHTMLForViewState(viewState)
+    })
+
+    window.setInterval(function () {
+        generateViewState(competitionId).then(viewState => {
+            createHTMLForViewState(viewState)
+        })
+    }, 40000);
+
+})()

--- a/football/lib/style.css
+++ b/football/lib/style.css
@@ -12,7 +12,6 @@
     text-rendering: optimizeLegibility;
     line-height: initial;
     font-size: 15px;
-    /*border: 3px solid yellow;*/
 }
 
 .score {
@@ -25,7 +24,6 @@
     line-height: initial;
     font-size: 25px;
     color: white;
-    /*border: 3px solid yellow;*/
     display: flex;
     justify-content: center;
     align-items: center;
@@ -40,7 +38,6 @@
     line-height: initial;
     font-size: 15px;
     color: white;
-    /*border: 3px solid red;*/
 }
 
 .scoreDivisor {
@@ -96,7 +93,6 @@
     text-align: center;
     color: #ffffff;
     word-break: break-word;
-    /*border: 3px solid red;*/
     vertical-align: middle;
     display: flex;
     justify-content: center;
@@ -108,7 +104,6 @@
 .teamsContainer, .scoreContainer {
     display: flex;
     margin: auto;
-    /*border: 3px solid green;*/
     text-align: justify;
     width: 20em;
 }
@@ -116,7 +111,6 @@
 .extraTimeScoreContainer {
     display: flex;
     margin: auto;
-    /*border: 3px solid green;*/
     text-align: center;
     justify-content: center;
     align-items: center;
@@ -203,7 +197,6 @@
 .teamFlag {
     font-size: 30px;
     padding: 0 10px 0 10px;
-    /*border: 3px solid yellow;*/
     width: 100%;
     text-align: center;
     overflow: auto;
@@ -217,12 +210,10 @@ ul {
     flex-flow: wrap column;
     max-height: 40em;
     -webkit-padding-start: 0px;
-    /*border: 3px solid yellow;*/
 }
 
 li {
     page-break-inside: avoid;
-    /*border: 3px solid green;*/
     display: flex;
     justify-content: space-around;
 }

--- a/football/lib/style.css
+++ b/football/lib/style.css
@@ -1,0 +1,228 @@
+.container {
+    height: 100vh;
+    background-image: linear-gradient(to bottom,#0e3877,#2B71B1);
+}
+
+.matchStatus {
+    font-family: "Avenir Next", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    font-weight: 500;
+    font-weight: bold;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    line-height: initial;
+    font-size: 15px;
+    /*border: 3px solid yellow;*/
+}
+
+.score {
+    font-family: "Avenir Next", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    font-weight: 500;
+    font-weight: bold;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    line-height: initial;
+    font-size: 25px;
+    color: white;
+    /*border: 3px solid yellow;*/
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.extraTimeScore {
+    font-family: "Avenir Next", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    font-weight: 500;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    line-height: initial;
+    font-size: 15px;
+    color: white;
+    /*border: 3px solid red;*/
+}
+
+.scoreDivisor {
+    padding: 0 5px;
+}
+
+.halfScore {
+    font-family: "Avenir Next", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    font-weight: 500;
+    font-weight: bold;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    line-height: initial;
+    font-size: 20px;
+    color: white;
+    display: flex;
+    align-items: center;
+    padding: 0 5px;
+}
+
+.date {
+    font-family: "Avenir Next", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    font-weight: 500;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    line-height: initial;
+    font-size: 10px;
+    color: #ffffff;
+}
+
+.competition {
+    font-family: "Avenir Next", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    font-weight: 500;
+    font-weight: bold;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    line-height: initial;
+    font-size: 30px;
+    text-align: center;
+    color: #ffffff;
+    width: 100%;
+}
+
+.homeTeam, .awayTeam, .matchDay {
+    font-family: "Avenir Next", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    font-weight: bold;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    font-size: 18px;
+    text-align: center;
+    color: #ffffff;
+    word-break: break-word;
+    /*border: 3px solid red;*/
+    vertical-align: middle;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0 10px 0px 10px;
+    width: 7em;
+}
+
+.teamsContainer, .scoreContainer {
+    display: flex;
+    margin: auto;
+    /*border: 3px solid green;*/
+    text-align: justify;
+    width: 20em;
+}
+
+.extraTimeScoreContainer {
+    display: flex;
+    margin: auto;
+    /*border: 3px solid green;*/
+    text-align: center;
+    justify-content: center;
+    align-items: center;
+    width: 10em;
+}
+
+.circleBase {
+    border-radius: 50%;
+    width: 0.5em;
+    height: 0.5em;
+    background: mediumspringgreen;
+}
+
+.circleBaseRed {
+    border-radius: 50%;
+    width: 0.5em;
+    height: 0.5em;
+    background: orangered;
+}
+
+.dotContainer {
+    padding: 0 1px;
+}
+
+.penaltiesDiv {
+    display: flex;
+    margin: auto;
+    text-align: center;
+    justify-content: center;
+    align-items: center;
+    padding: 0 5px;
+}
+
+.penalties {
+    display: flex;
+    text-align: center;
+    padding: 5px;
+}
+
+.vs {
+    font-family: "Avenir Next", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    font-weight: bold;
+    text-rendering: optimizeLegibility;
+    line-height: initial;
+    font-size: 15px;
+    color: #ffffff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.item {
+    display: flex;
+    justify-content: space-around;
+}
+
+.matchContainer {
+    display: flex;
+    justify-content: space-around;
+    border: 1px solid #00063a;
+    background: rgba(0, 0, 0, 0.2);
+    padding: 10px;
+    border-radius: 5px;
+    align-items: center;
+    flex-direction: column;
+    width: 20em;
+}
+
+.header {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    flex-direction: column;
+    padding-top: 10px;
+}
+
+.matchList {
+    list-style-type: none;
+    padding: 5px;
+}
+
+.teamFlag {
+    font-size: 30px;
+    padding: 0 10px 0 10px;
+    /*border: 3px solid yellow;*/
+    width: 100%;
+    text-align: center;
+    overflow: auto;
+}
+
+ul {
+    display: -ms-flexbox;           /* IE 10 */
+    display: -webkit-flex;          /* Safari 6.1+. iOS 7.1+ */
+    display: flex;
+    -webkit-flex-flow: wrap column; /* Safari 6.1+ */
+    flex-flow: wrap column;
+    max-height: 40em;
+    -webkit-padding-start: 0px;
+    /*border: 3px solid yellow;*/
+}
+
+li {
+    page-break-inside: avoid;
+    /*border: 3px solid green;*/
+    display: flex;
+    justify-content: space-around;
+}

--- a/football/lib/template.html
+++ b/football/lib/template.html
@@ -3,6 +3,7 @@
 <Head>
     <meta charSet="utf-8" />
     <meta name="competitionId" content={{competitionId}} />
+    <meta name="authToken" content={{authToken}} />
     <meta name="matchDay" content={{matchDay}} />
 </Head>
 <div class="container">

--- a/football/lib/template.html
+++ b/football/lib/template.html
@@ -1,0 +1,15 @@
+<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+<link rel="stylesheet" href="{{{__dirname}}}/style.css">
+<Head>
+    <meta charSet="utf-8" />
+    <meta name="competitionId" content={{competitionId}} />
+    <meta name="matchDay" content={{matchDay}} />
+</Head>
+<div class="container">
+    <div class="header">
+        <span class="competition">{{competition}}</span>
+        <span class="matchDay">ROUND {{matchDay}}/{{totalMatchDays}}</span>
+    </div>
+    <ul id="matchList"/>
+</div>
+<script src="{{{__dirname}}}/runtime.js"/>

--- a/football/package.json
+++ b/football/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "football-plugin",
+  "version": "1.0.5",
+  "main": "lib/index.js",
+  "repository": {},
+  "license": "MIT",
+  "dependencies": {
+    "dashboard-plugin": "https://github.com/novoda/dashboards/blob/master/plugin/dashboard-plugin-1.0.3.tgz?raw=true"
+  },
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "mocha": "^5.0.1"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "directories": {
+    "test": "test"
+  }
+}

--- a/football/package.json
+++ b/football/package.json
@@ -1,6 +1,6 @@
 {
   "name": "football-plugin",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "main": "lib/index.js",
   "repository": {},
   "license": "MIT",


### PR DESCRIPTION
This PR adds the football plugin to the Novoda dashboard.

As the idea is to have a realtime updated plugin because of the matches, we did the creation of the UI dinamically in the `runtime.js` file.

While configuring the dashboard you should be able to follow the following list of competitions:

 Competition-ID | Country | Competition Name
-- | -- | --
452 | Germany | 1. Bundesliga
453 | Germany | 2. Bundesliga
445 | England | Premier League
447 | England | League On
446 | England | Championship
456 | Italy | Serie A
459 | Italy | Serie B
455 | Spain | Primera Division
450 | France | Ligue 1
451 | France | Ligue 2
449 | Netherlands | Eredivisie
457 | Portugal | Primeira Liga
464 | Europe | Champions-League
467 | World | World-Cup

There are a few other avaliable ones but I'll add to the plugin a way of selecting a competition from a list instead of using its ID. (if that's even possible)


 World Cup | Champions League |  extratime and penalties example
-- | -- | --
<img width="1440" alt="screen shot 2018-04-24 at 13 21 37" src="https://user-images.githubusercontent.com/3766687/39184893-88ae068a-47c5-11e8-8d67-a971071640bb.png"> | <img width="1440" alt="screen shot 2018-04-24 at 13 22 21" src="https://user-images.githubusercontent.com/3766687/39184929-a51724b4-47c5-11e8-95b1-1192985cad27.png"> | <img width="355" alt="screen shot 2018-04-24 at 13 21 53" src="https://user-images.githubusercontent.com/3766687/39184931-a7bfd968-47c5-11e8-907f-1e012ecc2b4f.png">
